### PR TITLE
Fix assignment statement in IFHERK that fails for non-vector states 

### DIFF
--- a/examples/TimeMarching.ipynb
+++ b/examples/TimeMarching.ipynb
@@ -129,32 +129,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "2 methods for generic function <b>plan_intfact</b>:<ul><li> plan_intfact(a::<b>Real</b>, dims::<b>Tuple{Int64,Int64}</b>; <i>fftw_flags</i>) in CartesianGrids at <a href=\"file:///Users/jeff/.julia/packages/CartesianGrids/PDomS/src/gridoperations/intfact.jl\" target=\"_blank\">/Users/jeff/.julia/packages/CartesianGrids/PDomS/src/gridoperations/intfact.jl:61</a></li> <li> plan_intfact(a::<b>Real</b>, nodes::<b>Nodes{T,NX,NY,T1,DT} where DT<:(AbstractArray{T,2} where T) where T1<:Number</b>; <i>fftw_flags</i>)<i> where {T<:CartesianGrids.CellType, NX, NY}</i> in CartesianGrids at <a href=\"file:///Users/jeff/.julia/packages/CartesianGrids/PDomS/src/gridoperations/intfact.jl\" target=\"_blank\">/Users/jeff/.julia/packages/CartesianGrids/PDomS/src/gridoperations/intfact.jl:77</a></li> </ul>"
-      ],
       "text/plain": [
-       "# 2 methods for generic function \"plan_intfact\":\n",
-       "[1] plan_intfact(a::Real, dims::Tuple{Int64,Int64}; fftw_flags) in CartesianGrids at /Users/jeff/.julia/packages/CartesianGrids/PDomS/src/gridoperations/intfact.jl:61\n",
-       "[2] plan_intfact(a::Real, nodes::Nodes{T,NX,NY,T1,DT} where DT<:(AbstractArray{T,2} where T) where T1<:Number; fftw_flags) where {T<:CartesianGrids.CellType, NX, NY} in CartesianGrids at /Users/jeff/.julia/packages/CartesianGrids/PDomS/src/gridoperations/intfact.jl:77"
+       "plan_intfact (generic function with 2 methods)"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "methods(plan_intfact)"
+    "CartesianGrids.plan_intfact"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -166,13 +161,13 @@
        "   Time step size 1.0\n"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "ifherk = IFHERK(u,f,Δt,plan_intfact,plan_constraints,(r₁,r₂),rk=ConstrainedSystems.Euler)"
+    "ifherk = IFHERK(u,f,Δt,CartesianGrids.plan_intfact,plan_constraints,(r₁,r₂),rk=ConstrainedSystems.Euler)"
    ]
   },
   {

--- a/src/timemarching/ifherk.jl
+++ b/src/timemarching/ifherk.jl
@@ -270,7 +270,7 @@ function (scheme::IFHERK{NS,FH,FR1,FR2,FC,FS,TU,TF})(t::Float64,u::TU) where
       # could solve this system for the whole tuple, too...
       fill!(f[el],0.0)
       ldiv!(sol[el],S[el],SaddleVector(ubuffer[el],fbuffer[el]))
-      ubuffer[el] .= S[el].A⁻¹B₁ᵀf
+      ubuffer[el] .= TU(S[el].A⁻¹B₁ᵀf)
       #tmp = S[i][el]\(ubuffer[el],fbuffer[el])  # solve saddle point system
       #u[el] .= tmp[1]
       #f[el] .= tmp[2]
@@ -307,7 +307,7 @@ function (scheme::IFHERK{NS,FH,FR1,FR2,FC,FS,TU,TF})(t::Float64,u::TU) where
         fbuffer[el] .= ftmp[el]
         fill!(f[el],0.0)
         ldiv!(sol[el],S[el],SaddleVector(ubuffer[el],fbuffer[el]))
-        ubuffer[el] .= S[el].A⁻¹B₁ᵀf
+        ubuffer[el] .= TU(S[el].A⁻¹B₁ᵀf)
 
         #tmp = S[i][el]\(ubuffer[el],fbuffer[el])  # solve saddle point system
         #u[el] .= tmp[1]
@@ -393,7 +393,7 @@ function (scheme::IFHERK{NS,FH,FR1,FR2,FC,FS,TU,TF})(t::Float64,u::TU) where
     fbuffer .= r₂(u,tᵢ₊₁) # r₂
     sol .= S\SaddleVector(ubuffer,fbuffer)  # solve saddle point system
 
-    ubuffer .= S.A⁻¹B₁ᵀf
+    ubuffer .= TU(S.A⁻¹B₁ᵀf)
     tᵢ₊₁ = t + rkdt.c[i]
 
     # diffuse the scratch vectors
@@ -417,7 +417,7 @@ function (scheme::IFHERK{NS,FH,FR1,FR2,FC,FS,TU,TF})(t::Float64,u::TU) where
       end
       fbuffer .= r₂(u,tᵢ₊₁) # r₂
       sol .= S\SaddleVector(ubuffer,fbuffer)  # solve saddle point system
-      ubuffer .= S.A⁻¹B₁ᵀf
+      ubuffer .= TU(S.A⁻¹B₁ᵀf)
       tᵢ₊₁ = t + rkdt.c[i]
 
       #ldiv!((u,f),S[i],(ubuffer,fbuffer)) # solve saddle point system

--- a/test/timemarching.jl
+++ b/test/timemarching.jl
@@ -78,4 +78,37 @@ using LinearAlgebra
 
   end
 
+  @testset "Constrained using IFHERK" begin
+
+  nx = 129; ny = 129; Lx = 2.0; Δx = Lx/(nx-2)
+  u₀ = Nodes(Dual,(nx,ny)); # field initial condition
+
+  n = 128; θ = range(0,stop=2π,length=n+1)
+  R = 0.5; xb = 1.0 .+ R*cos.(θ); yb = 1.0 .+ R*sin.(θ)
+  X = VectorData(xb[1:n],yb[1:n])
+  f = ScalarData(X); # to be used as the Lagrange multiplier
+
+  reg = Regularize(X,Δx;issymmetric=true)
+  Hmat, Emat = RegularizationMatrix(reg,f,u₀)
+  plan_constraints(u::Nodes{Dual,nx,ny},t::Float64) = Hmat, Emat
+
+  r₁(u::Nodes{T,NX,NY},t::Float64) where {T,NX,NY} = Nodes(T,u); # sets to zeros
+  r₂(u::Nodes{T,NX,NY},t::Float64) where {T,NX,NY} = 1.0; # sets uniformly to 1.0
+
+  Δt = 1.0
+  t = 0.0
+  u = deepcopy(u₀)
+
+  solver = IFHERK(u,f,Δt,CartesianGrids.plan_intfact,plan_constraints,(r₁,r₂),
+                rk=ConstrainedSystems.RK31)
+
+
+  for i = 1:20
+      t, u, f = solver(t,u)
+  end
+
+  @test isapprox(LinearAlgebra.norm(u),0.3008,atol=1e-4)
+
+  end
+
 end


### PR DESCRIPTION
The current version of IFHERK contains a line that attempts to assign the current value of the saddle-point system's temporary vector to `ubuffer`. This fails when `ubuffer` is not a `Vector` type. This PR fixes this. It also adds a test to check for it.