### PR TITLE
Fixed parameter names

### DIFF
--- a/src/saddlepoint/saddlesystems.jl
+++ b/src/saddlepoint/saddlesystems.jl
@@ -2,7 +2,7 @@
 
 abstract type SchurSolverType end
 
-struct SaddleSystem{T,Ns,Nc,TF,TU,TS<:SchurSolverType}
+struct SaddleSystem{T,Ns,Nc,TU,TF,TS<:SchurSolverType}
     A :: LinearMap{T}
     B₂ :: LinearMap{T}
     B₁ᵀ :: LinearMap{T}


### PR DESCRIPTION
The names TU and TF were switched in the definition of the SaddleSystem type (with respect to their order in the call on line 66 to the default constructor)