### PR TITLE
Enabling interpolation of solution data

### DIFF
--- a/src/ConstrainedSystems.jl
+++ b/src/ConstrainedSystems.jl
@@ -23,7 +23,7 @@ import RecursiveArrayTools: recursivecopy, recursivecopy!, recursive_mean
 using LinearAlgebra
 import LinearAlgebra: ldiv!, mul!, *, \, I
 
-import Base: size, eltype
+import Base: size, eltype, *, /, +, -
 
 export SaddleSystem, SaddleVector, state, constraint, aux_state, linear_map
 export solvector, mainvector

--- a/src/timemarching/algorithms.jl
+++ b/src/timemarching/algorithms.jl
@@ -424,7 +424,8 @@ end
       err = internalnorm(udiff,ttmp)
       #println("error = ",err)
     end
-    @.. constraint(u) /= (dt*ã33)
+    z = constraint(u)
+    @.. z /= (dt*ã33)
 
     # Final steps
     integrator.p = param_update_func(u,ptmp,t)
@@ -559,7 +560,8 @@ end
     err = internalnorm(udiff,t+dt)
     #println("error = ",err)
   end
-  @.. constraint(u) /= dt
+  z = constraint(u)
+  @.. z /= dt
 
   # Final steps
   integrator.p = param_update_func(u,pold_ptr,t)

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -90,3 +90,68 @@ state_r1(r1::ArrayPartition) = r1.x[1]
 
 aux_r1(r1) = nothing
 aux_r1(r1::ArrayPartition) = r1.x[2]
+
+
+# To extend interpolation to ArrayPartition but preserve the types of entries
+Base.BroadcastStyle(::Type{<:ArrayPartition}) = Broadcast.ArrayStyle{ArrayPartition}()
+
+# This is necessary for scalar multiplications
+function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{ArrayPartition}}, ::Type{ElType}) where ElType
+    ap = find_ap(bc)
+    ArrayPartition(similar.(ap.x))
+end
+
+# Find the first ArrayPartition in the Broadcast wrapper
+find_ap(bc::Base.Broadcast.Broadcasted) = find_ap(bc.args)
+find_ap(args::Tuple) = find_ap(find_ap(args[1]), Base.tail(args))
+find_ap(x) = x
+find_ap(::Tuple{}) = nothing
+find_ap(a::ArrayPartition, rest) = a
+find_ap(::Any, rest) = find_ap(rest)
+
+
+# Extended copyto! for broadcasting to ArrayPartition, fusing the dot operations
+# It calls copyto! of the individual x fields, since these are possibly optimized
+@inline function Base.copyto!(dest::ArrayPartition, bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{ArrayPartition}})
+    if bc.f === identity && bc.args isa Tuple{AbstractArray} # only a single input argument to broadcast!
+        A = bc.args[1]
+        if axes(dest) == axes(A)
+            return copyto!(dest, A)
+        end
+    end
+    bcf = Base.Broadcast.flatten(bc)
+    for i in eachindex(dest.x)
+        copyto!(dest.x[i],unpack(bcf,i))
+    end
+
+    return dest
+end
+
+# This fixes a flaw in the copyto! in RecursiveArrayTools
+function Base.copyto!(dest::ArrayPartition,src::ArrayPartition)
+    @assert length(src) == length(dest)
+    if size.(dest.x) == size.(src.x)
+       @inbounds for i in eachindex(src.x)
+        dest.x[i] .= src.x[i]
+      end
+    else
+      cnt = 0
+      for i in eachindex(dest.x)
+        x = dest.x[i]
+        for k in eachindex(x)
+          cnt += 1
+          x[k] = src[cnt]
+        end
+      end
+    end
+    dest
+end
+
+# Generate a Broadcasted entry with only one x field entry of ArrayPartition
+@inline unpack(bc::Broadcast.Broadcasted, i) = Broadcast.Broadcasted(bc.f, unpack_args(i, bc.args))
+unpack(x,::Any) = x
+unpack(x::ArrayPartition, i) = x.x[i]
+
+@inline unpack_args(i, args::Tuple) = (unpack(args[1], i), unpack_args(i, Base.tail(args))...)
+unpack_args(i, args::Tuple{Any}) = (unpack(args[1], i),)
+unpack_args(::Any, args::Tuple{}) = ()


### PR DESCRIPTION
Previously, the solution interpolation accessed by `sol(t)` syntax was not possible with the `ArrayPartition` types used in this package. This was due to a need for dotted multiplications with scalar quantities. In this PR we have extended copyto! to allow fused dot operations on `ArrayPartition` types. (This also has the benefit of greatly speeding up operations on `ArrayPartition` types)