### PR TITLE
fix update_exogenous! behavior

### DIFF
--- a/src/timemarching/algorithms.jl
+++ b/src/timemarching/algorithms.jl
@@ -233,8 +233,8 @@ end
     end
     zero_vec!(xtmp)
     B1_times_z!(utmp,S[1])
-    pold_ptr = ptmp
-    pnew_ptr = p
+    pold_ptr = p
+    pnew_ptr = ptmp
 
     ldiv!(yprev,Hhalfdt,yprev)
     ldiv!(state(k1),Hhalfdt,state(k1))


### PR DESCRIPTION
This PR switches the assignment of `pold_ptr` and `pnew_ptr`. I am not sure if the original code was like this for a reason (so not a bug), but the old code swapped `pold_ptr` and `pnew_ptr` before stage 2, which swapped a non-zero `p.motions.m.a_edof_buffer` with a zero vector (from `ptmp`). If `a_edof_buffer` is set with `RigidBodyTools.update_exogenous!`, that zero vector wouldn't be updated in `RigidBodyTools.motion_rhs!`, and line 245 in algorithms.jl would give a wrong dxdt.