### PR TITLE
Fix C matrix treatment in time marching

### DIFF
--- a/src/timemarching/testproblems.jl
+++ b/src/timemarching/testproblems.jl
@@ -344,15 +344,16 @@ function basic_constrained_if_problem_with_cmatrix(;tmax=1.0,iip=true)
   B1T = 1.0
   B2 = 1.0
   β = 1.2
-  p = [α,B1T,B2,β]
+  r2 = 1.0
+  p = [α,B1T,B2,β,r2]
 
   L = α*I
 
   ode_rhs!(dy,y,x,p,t) = fill!(dy,0.0)
   ode_rhs(y,x,p,t) = zero(y)
 
-  constraint_rhs!(dz,x,p,t) = fill!(dz,0.0)
-  constraint_rhs(x,p,t) = zeros(1)
+  constraint_rhs!(dz,x,p,t) = fill!(dz,p[5])
+  constraint_rhs(x,p,t) = p[5]*ones(1)
 
   function op_constraint_force!(dy::Vector{Float64},z::Vector{Float64},x,p)
     dy .= p[2]*z
@@ -381,8 +382,8 @@ function basic_constrained_if_problem_with_cmatrix(;tmax=1.0,iip=true)
   tspan = (0.0,tmax)
   prob = ODEProblem(f,u₀,tspan,p)
 
-  xexact(t) = exp((α+1/β)*t)*y0
-  yexact(t) = -xexact(t)/β
+  xexact(t) = exp((α+1/β)*t)*y0 + r2/β/(α+1/β)*(1 - exp((α+1/β)*t))
+  yexact(t) = (r2 - xexact(t))/β
 
   return prob, xexact, yexact
 end

--- a/src/timemarching/testproblems.jl
+++ b/src/timemarching/testproblems.jl
@@ -331,3 +331,58 @@ function partitioned_problem(;tmax=1.0,iip=true)
   return prob, xexact, yexact
 
 end
+
+function basic_constrained_if_problem_with_cmatrix(;tmax=1.0,iip=true)
+
+  y0 = 1
+  y₀ = Float64[y0]
+  z₀ = Float64[0]
+  u₀ = solvector(state=y₀,constraint=z₀)
+  du = deepcopy(u₀)
+
+  α = -1.0
+  B1T = 1.0
+  B2 = 1.0
+  β = 1.2
+  p = [α,B1T,B2,β]
+
+  L = α*I
+
+  ode_rhs!(dy,y,x,p,t) = fill!(dy,0.0)
+  ode_rhs(y,x,p,t) = zero(y)
+
+  constraint_rhs!(dz,x,p,t) = fill!(dz,0.0)
+  constraint_rhs(x,p,t) = zeros(1)
+
+  function op_constraint_force!(dy::Vector{Float64},z::Vector{Float64},x,p)
+    dy .= p[2]*z
+  end
+
+  op_constraint_force(z::Vector{Float64},x,p) = op_constraint_force!(deepcopy(y₀),z,x,p)
+
+  function constraint_op!(dz::Vector{Float64},y::Vector{Float64},x,p)
+    dz .= p[3]*y
+  end
+  constraint_op(y::Vector{Float64},x,p) = constraint_op!(deepcopy(z₀),y,x,p)
+
+  function constraint_reg!(dz::Vector{Float64},z::Vector{Float64},x,p)
+    dz .= p[4]*z
+  end
+  constraint_reg(z::Vector{Float64},x,p) = constraint_reg!(deepcopy(z₀),z,x,p)
+
+  if iip
+    f = ConstrainedODEFunction(ode_rhs!,constraint_rhs!,op_constraint_force!,
+                              constraint_op!,L,constraint_reg!,_func_cache=deepcopy(du))
+  else
+    f = ConstrainedODEFunction(ode_rhs,constraint_rhs,op_constraint_force,
+                              constraint_op,L,constraint_reg)
+   end
+
+  tspan = (0.0,tmax)
+  prob = ODEProblem(f,u₀,tspan,p)
+
+  xexact(t) = exp((α+1/β)*t)*y0
+  yexact(t) = -xexact(t)/β
+
+  return prob, xexact, yexact
+end

--- a/src/timemarching/timesaddlesystems.jl
+++ b/src/timemarching/timesaddlesystems.jl
@@ -1,6 +1,6 @@
 
 # called directly by alg_cache for iip algorithms and indirectly by non-sc algorithms
-function SaddleSystem(A,f::ConstrainedODEFunction{true},p,pold,ducache,solver)
+function SaddleSystem(A,f::ConstrainedODEFunction{true},p,pold,ducache,solver;cfact=1.0)
     nully, nullz = state(ducache), constraint(ducache)
     du_aux = aux_state(ducache)
     @inline B₁ᵀ(z) = (zero_vec!(ducache);
@@ -11,12 +11,12 @@ function SaddleSystem(A,f::ConstrainedODEFunction{true},p,pold,ducache,solver)
                      constraint(ducache) .*= -1.0; return constraint(ducache))
     @inline C(z) = (zero_vec!(ducache);
                     _constraint_neg_C!(ducache,f,solvector(state=nully,constraint=z,aux_state=du_aux),p,0.0);
-                     constraint(ducache) .*= -1.0; return constraint(ducache))
+                     constraint(ducache) .*= -cfact; return constraint(ducache))
     SaddleSystem(A,B₂,B₁ᵀ,C,mainvector(ducache),solver=solver)
 end
 
 # called directly by oop algorithms
-function SaddleSystem(A,f::ConstrainedODEFunction{false},p,pold,ducache,solver)
+function SaddleSystem(A,f::ConstrainedODEFunction{false},p,pold,ducache,solver;cfact=1.0)
 
     nully, nullz = state(ducache), constraint(ducache)
     du_aux = aux_state(ducache)
@@ -27,7 +27,7 @@ function SaddleSystem(A,f::ConstrainedODEFunction{false},p,pold,ducache,solver)
                      constraint(ducache) .*= -1.0; return constraint(ducache))
     @inline C(z) = (zero_vec!(ducache);
                      ducache .= _constraint_neg_C(f,solvector(state=nully,constraint=z,aux_state=du_aux),p,0.0);
-                     constraint(ducache) .*= -1.0; return constraint(ducache))
+                     constraint(ducache) .*= -cfact; return constraint(ducache))
     SaddleSystem(A,B₂,B₁ᵀ,C,mainvector(ducache),solver=solver)
 end
 

--- a/test/algconvergence.jl
+++ b/test/algconvergence.jl
@@ -99,7 +99,7 @@ solutions2 = [solve(prob,IFHEEuler();dt=dts[i]) for i=1:length(dts)]
 𝒪est1 = compute𝒪est(solutions1,1,xexact)
 𝒪est2 = compute𝒪est(solutions2,1,xexact)
 
-@test 𝒪est1[:l2][1] ≈ 1 atol=testTol
+@test 𝒪est1[:l2][1] ≈ 1 atol=testTol # IFHERK only 1st order convergent on this problem
 @test 𝒪est2[:l2][1] ≈ 1 atol=testTol
 
 ### out of place ###
@@ -177,7 +177,7 @@ solutions2 = [solve(prob,IFHEEuler();dt=dts[i]) for i=1:length(dts)]
 𝒪est1 = compute𝒪est(solutions1,1,xexact)
 𝒪est2 = compute𝒪est(solutions2,1,xexact)
 
-@test 𝒪est1[:l2][1] ≈ 1 atol=testTol
+@test 𝒪est1[:l2][1] ≈ 1 atol=testTol # IFHERK only 1st order convergent on this problem
 @test 𝒪est2[:l2][1] ≈ 1 atol=testTol
 
 end

--- a/test/algconvergence.jl
+++ b/test/algconvergence.jl
@@ -91,6 +91,17 @@ solutions2 = [solve(prob,IFHEEuler();dt=dts[i]) for i=1:length(dts)]
 @test 𝒪est1[:l2][1] ≈ 2 atol=testTol
 @test 𝒪est2[:l2][1] ≈ 1 atol=testTol
 
+prob, xexact, yexact = ConstrainedSystems.basic_constrained_if_problem_with_cmatrix(iip=true)
+
+solutions1 = [solve(prob,LiskaIFHERK();dt=dts[i]) for i=1:length(dts)]
+solutions2 = [solve(prob,IFHEEuler();dt=dts[i]) for i=1:length(dts)]
+
+𝒪est1 = compute𝒪est(solutions1,1,xexact)
+𝒪est2 = compute𝒪est(solutions2,1,xexact)
+
+@test 𝒪est1[:l2][1] ≈ 1 atol=testTol
+@test 𝒪est2[:l2][1] ≈ 1 atol=testTol
+
 ### out of place ###
 
 # Unconstrained
@@ -156,6 +167,17 @@ solutions2 = [solve(prob,IFHEEuler();dt=dts[i]) for i=1:length(dts)]
 𝒪est2 = compute𝒪est(solutions2,1,xexact)
 
 @test 𝒪est1[:l2][1] ≈ 2 atol=testTol
+@test 𝒪est2[:l2][1] ≈ 1 atol=testTol
+
+prob, xexact, yexact = ConstrainedSystems.basic_constrained_if_problem_with_cmatrix(iip=false)
+
+solutions1 = [solve(prob,LiskaIFHERK();dt=dts[i]) for i=1:length(dts)]
+solutions2 = [solve(prob,IFHEEuler();dt=dts[i]) for i=1:length(dts)]
+
+𝒪est1 = compute𝒪est(solutions1,1,xexact)
+𝒪est2 = compute𝒪est(solutions2,1,xexact)
+
+@test 𝒪est1[:l2][1] ≈ 1 atol=testTol
 @test 𝒪est2[:l2][1] ≈ 1 atol=testTol
 
 end


### PR DESCRIPTION
This PR fixes the treatment of the C matrix in the time marching algorithms. However, only first order convergence is achieved for the ostensibly 2nd-order IFHERK algorithm in this case.