### PR TITLE
Fixing some unnecessary memory allocations

### DIFF
--- a/src/saddlepoint/arithmetic.jl
+++ b/src/saddlepoint/arithmetic.jl
@@ -74,7 +74,7 @@ end
 
 function ldiv!(sol::Union{Tuple{AbstractVector{T},AbstractVector{T}},AbstractVectorOfArray{T}},sys::SaddleSystem{T,Ns,Nc},
               rhs::Union{Tuple{AbstractVector{T},AbstractVector{T}},AbstractVectorOfArray{T}}) where {T,Ns,Nc}
-    @unpack A⁻¹, B₂, B₁ᵀ, B₂A⁻¹r₁, P, S⁻¹, _f_buf, A⁻¹B₁ᵀf = sys
+    @unpack A⁻¹, B₂, B₁ᵀ, B₂A⁻¹r₁, P, S⁻¹, _f_buf, _u_buf, A⁻¹B₁ᵀf = sys
 
     N = Ns+Nc
     u,f = sol
@@ -92,7 +92,9 @@ function ldiv!(sol::Union{Tuple{AbstractVector{T},AbstractVector{T}},AbstractVec
         f .= S⁻¹*_f_buf
         f .= P*f
     end
-    A⁻¹B₁ᵀf .= A⁻¹*B₁ᵀ*f
+    _u_buf .= B₁ᵀ*f
+    mul!(A⁻¹B₁ᵀf,A⁻¹,_u_buf)
+
     u .-= A⁻¹B₁ᵀf
 
 

--- a/src/saddlepoint/saddlesystems.jl
+++ b/src/saddlepoint/saddlesystems.jl
@@ -14,6 +14,7 @@ struct SaddleSystem{T,Ns,Nc,TU,TF,TS<:SchurSolverType}
     A⁻¹B₁ᵀf :: Vector{T}
     B₂A⁻¹r₁ :: Vector{T}
     _f_buf :: Vector{T}
+    _u_buf :: Vector{T}
     P :: LinearMap{T}
     S :: LinearMap{T}
     S⁻¹ :: LinearMap{T}
@@ -74,7 +75,7 @@ function SaddleSystem(A::LinearMap{T},B₂::LinearMap{T},B₁ᵀ::LinearMap{T},C
     S⁻¹ = _inverse_function(S,solver,kwargs...)
     C⁻¹ = _inverse_function(C,solver,kwargs...)
 
-    return SaddleSystem{T,ns,nc,TU,TF,solver}(A,B₂,B₁ᵀ,C,A⁻¹,C⁻¹,zeros(T,ns),zeros(T,nc),zeros(T,nc),P,S,S⁻¹)
+    return SaddleSystem{T,ns,nc,TU,TF,solver}(A,B₂,B₁ᵀ,C,A⁻¹,C⁻¹,zeros(T,ns),zeros(T,nc),zeros(T,nc),zeros(T,ns),P,S,S⁻¹)
 end
 
 ##### Solver functions #####


### PR DESCRIPTION
- Replaced saddle point operations with ldiv to avoid memory allocations.
- Eliminated a memory allocation in saddle system solve by splitting a composite op